### PR TITLE
Add unit test for /fulltext API

### DIFF
--- a/app/search/tests/test_fulltext.py
+++ b/app/search/tests/test_fulltext.py
@@ -1,0 +1,11 @@
+from fastapi.testclient import TestClient
+from app.search.aisearch.main import app
+from unittest.mock import patch
+
+def test_fulltext():
+    client = TestClient(app)
+    mock_response = [{"sourcepage": "test_page", "content": "test_content"}]
+    with patch("app.search.aisearch.main.execute_fulltext_search", return_value=mock_response):
+        response = client.get("/fulltext", params={"query": "test"})
+    assert response.status_code == 200
+    assert response.json() == mock_response


### PR DESCRIPTION
Related to #55

Add unit test for `@app.get('/fulltext')` API.

* Create a new test file `app/search/tests/test_fulltext.py`.
* Import necessary modules: `TestClient` from `fastapi.testclient`, `app` from `app.search.aisearch.main`, and `patch` from `unittest.mock`.
* Define a test function `test_fulltext` to verify the API response.
* Mock the response of `execute_fulltext_search` to return a predefined result.
* Send a GET request to `/fulltext` and assert the response status and content.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kohei3110/aoai-ner/pull/56?shareId=6cbe3b33-3236-4823-b4ea-b4a74284bd3f).